### PR TITLE
Improve column header customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
 # OpenXL.jl Changelog
 
 The latest version of this file can be found at the master branch of the [OpenXL.jl repository](https://github.com/bhftbootcamp/OpenXL.jl).
+
+## 2.0.0 (15/07/2024)
+
+### Added
+
+- Added the ability to set headers using a vector for methods `xl_rowtable` and `xl_columntable`.
+- Added support for rows iteration by `Base.eachrow` method.
+- Added method `xl_open` for reading and parsing XL files.
+- Added methods `column_letter_to_index` and `index_to_column_letter` to the documentation.
+- General fixes and improvements.
+
+### Changed
+
+- Renamed accessor methods `xl_name` and `xl_names` to `xl_sheetname` and `xl_sheetnames`.
+- Renamed print method `xl_print_sheet` to `xl_print`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OpenXL"
 uuid = "5439f3e2-bb62-4031-b438-a07447f64eb9"
-version = "1.1.0"
+version = "2.0.0"
 
 [deps]
 Serde = "db9b398d-9517-45f8-9a95-92af99003e0e"

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ julia> xlsx = xl_parse(xl_sample_ticker24h_xlsx())
 1-element XLWorkbook:
  2682x19 XLSheet("Ticker24h")
 
-julia> DataFrame(xl_rowtable(xlsx["Ticker24h"], header = true))
+julia> DataFrame(eachrow(xlsx["Ticker24h"], header = true))
 2681×19 DataFrame
   Row │ symbol    askPrice    askQty      bidPrice    bidQty      lastQty    openPrice    highPrice    lowPrice    lastPrice   openTime                       closeTime                      prevClosePrice  priceChange  priceChangePercent  quoteVolume    count     volume         weightedAvgPrice
       │ String    Float64     Float64     Float64     Float64     Float64    Float64      Float64      Float64     Float64     String                         String                         Float64         Float64      Float64             Float64        Float64   Float64        Float64          

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -114,7 +114,7 @@ julia> xlsx = xl_parse(xl_sample_ticker24h_xlsx())
 1-element XLWorkbook:
  2682x19 XLSheet("Ticker24h")
 
-julia> DataFrame(xl_rowtable(xlsx["Ticker24h"], header = true))
+julia> DataFrame(eachrow(xlsx["Ticker24h"], header = true))
 2681×19 DataFrame
   Row │ symbol    askPrice    askQty      bidPrice    bidQty      lastQty    openPrice    highPrice    lowPrice    lastPrice   openTime                       closeTime                      prevClosePrice  priceChange  priceChangePercent  quoteVolume    count     volume         weightedAvgPrice 
       │ String    Float64     Float64     Float64     Float64     Float64    Float64      Float64      Float64     Float64     String                         String                         Float64         Float64      Float64             Float64        Float64   Float64        Float64          

--- a/docs/src/pages/api_reference.md
+++ b/docs/src/pages/api_reference.md
@@ -2,6 +2,7 @@
 
 ```@docs
 xl_parse
+xl_open
 ```
 
 ## Types
@@ -18,5 +19,13 @@ XLTable
 ```@docs
 xl_rowtable
 xl_columntable
-xl_print_sheet
+eachrow
+xl_print
+```
+
+## Utils
+
+```@docs
+OpenXL.index_to_column_letter
+OpenXL.column_letter_to_index
 ```

--- a/src/OpenXL.jl
+++ b/src/OpenXL.jl
@@ -1,11 +1,12 @@
 module OpenXL
 
 export xl_parse,
+    xl_open,
     xl_rowtable,
     xl_columntable,
-    xl_print_sheet,
-    xl_name,
-    xl_names,
+    xl_print,
+    xl_sheetname,
+    xl_sheetnames,
     xl_nrow,
     xl_ncol
 
@@ -29,8 +30,9 @@ const Maybe{T} = Union{Nothing,T}
 
 include("utils.jl")
 include("xml_structure.jl")
-include("interface.jl")
 include("parser.jl")
+include("interface.jl")
+include("table.jl")
 include("print.jl")
 include("sample_data.jl")
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,4 +1,4 @@
-# interface
+# xl_interface
 
 """
     AbstractXLSheet <: AbstractArray{Any,2}
@@ -6,8 +6,6 @@
 Abstract supertype for [`XLSheet`](@ref) and [`XLTable`](@ref).
 """
 abstract type AbstractXLSheet <: AbstractArray{Any,2} end
-
-#__XLTable
 
 """
     XLTable <: AbstractXLSheet
@@ -22,7 +20,7 @@ Supports the same table operations as `XLSheet`.
 - `xl_nrow(x::XLTable)`: Number of rows.
 - `xl_ncol(x::XLTable)`: Number of columns.
 
-See also: [`xl_rowtable`](@ref), [`xl_columntable`](@ref), [`xl_print_sheet`](@ref).
+See also: [`xl_rowtable`](@ref), [`xl_columntable`](@ref), [`xl_print`](@ref).
 
 ## Examples
 ```julia-repl
@@ -55,7 +53,6 @@ xl_ncol(x::AbstractXLSheet) = size(x, 2)
 
 Base.:(==)(x::XLTable, y::XLTable) = x.data == y.data
 Base.isequal(x::XLTable, y::XLTable) = isequal(x.data, y.data)
-
 Base.getindex(x::XLTable, i::Int) = x.data[i]
 
 function Base.getindex(x::XLTable, inds::Vararg{Any,2})
@@ -104,20 +101,18 @@ Base.convert(::Type{XLTable}, x::AbstractMatrix) = XLTable(x)
 Base.convert(::Type{Matrix}, x::XLTable) = x.data
 
 function Base.show(io::IO, x::XLTable; kw...)
-    xl_print_sheet(io, x; kw...)
+    xl_print(io, x; kw...)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", x::XLTable; kw...)
     num_rows, num_cols = size(x)
     print(io, num_rows, "x", num_cols, " XLTable\n")
-    xl_print_sheet(io, x; kw...)
+    xl_print(io, x; kw...)
 end
 
 function Base.print(io::IO, x::XLTable; kw...)
-    xl_print_sheet(io, x; compact = false, kw...)
+    xl_print(io, x; compact = false, kw...)
 end
-
-#__ XLSheet
 
 """
     XLSheet <: AbstractXLSheet
@@ -132,11 +127,11 @@ The sheet slice will be converted into a separate [`XLTable`](@ref).
 - `table::XLTable`: Table representation.
 
 ## Accessors
-- `xl_name(x::XLSheet)`: Sheet name.
+- `xl_sheetname(x::XLSheet)`: Sheet name.
 - `xl_nrow(x::XLTable)`: Number of rows.
 - `xl_ncol(x::XLTable)`: Number of columns.
 
-See also: [`xl_rowtable`](@ref), [`xl_columntable`](@ref), [`xl_print_sheet`](@ref).
+See also: [`xl_rowtable`](@ref), [`xl_columntable`](@ref), [`xl_print`](@ref).
 
 ## Examples
 
@@ -164,8 +159,6 @@ struct XLSheet <: AbstractXLSheet
     table::XLTable
 end
 
-xl_name(x::XLSheet) = x.name
-
 Base.size(x::XLSheet) = size(x.table)
 Base.size(x::XLSheet, dim) = size(x.table, dim)
 
@@ -174,6 +167,8 @@ Base.isequal(x::XLSheet, y::XLSheet) = isequal(x.table, y.table)
 
 Base.getindex(x::XLSheet, inds::Any...) = x.table[inds...]
 Base.setindex!(x::XLSheet, value, inds...) = setindex!(x.table, value, inds...)
+
+xl_sheetname(x::XLSheet) = x.name
 
 function Base.show(io::IO, x::XLSheet)
     num_rows, num_cols = size(x)
@@ -193,97 +188,6 @@ function Base.print(io::IO, x::XLSheet; kw...)
 end
 
 """
-    xl_rowtable(sheet::AbstractXLSheet; kw...) -> Vector{NamedTuple}
-
-Converts sheet rows to a `Vector` of `NamedTuples`.
-
-## Keyword arguments
-- `alt_keys::Dict{String,String}`: Alternative custom column headers.
-- `header::Bool = false`: Use first row elements as column headers.
-
-## Examples
-
-```julia-repl
-julia> xlsx = xl_parse(xl_sample_stock_xlsx())
-1-element XLWorkbook:
- 41x6 XLSheet("Stock")
-
-julia> xl_rowtable(xlsx["Stock"]["A1:C30"], header = true)
-29-element Vector{NamedTuple{(:name, :price, :h24)}}:
- (name = "MSFT", price = "430.16", h24 = "0.0007")
- (name = "AAPL", price = "189.98", h24 = "-0.0005")
- (name = "NVDA", price = "1064.69", h24 = "0.0045")
- (name = "GOOG", price = "176.33", h24 = "-0.0006")
- ⋮
- (name = "LLY", price = 807.43, h24 = -0.0024)
- (name = "AVGO", price = 1407.84, h24 = 0.0036)
-```
-"""
-function xl_rowtable(
-    x::AbstractXLSheet;
-    alt_keys::Dict{String,String} = Dict{String,String}(),
-    header::Bool = false,
-)
-    column_keys, t_data = if header
-        headers = x[1, :]
-        replace!(headers, alt_keys...)
-        Symbol.(headers), view(x, 2:xl_nrow(x), :)
-    else
-        gen_column_keys(xl_ncol(x), alt_keys), x
-    end
-
-    return map(eachrow(t_data)) do row
-        return NamedTuple{Tuple(column_keys)}(row)
-    end
-end
-
-"""
-    xl_columntable(sheet::AbstractXLSheet; kw...) -> Vector{NamedTuple}
-
-Converts sheet columns to a `Vector` of `NamedTuples`.
-
-## Keyword arguments
-- `alt_keys::Dict{String,String}`: Alternative custom column headers.
-- `header::Bool = false`: Use first row elements as column headers.
-
-## Examples
-
-```julia-repl
-julia> xlsx = xl_parse(xl_sample_stock_xlsx())
-1-element XLWorkbook:
- 41x6 XLSheet("Stock")
-
-julia> alt_keys = Dict("A" => "Name", "B" => "Price", "C" => "H24");
-
-julia> xl_columntable(xlsx["Stock"][2:end, 1:3]; alt_keys)
-(
-    Name = Any["MSFT", "AAPL"  …  "JNJ", "ORCL"]
-    Price = Any[430.16, 189.98  …  146.97, 122.91],
-    H24 = Any[0.0007, -0.0005  …  0.0007, -0.0003],
-)
-```
-"""
-function xl_columntable(
-    x::AbstractXLSheet;
-    alt_keys::Dict{String,String} = Dict{String,String}(),
-    header::Bool = false,
-)
-    column_keys, t_data = if header
-        headers = x[1, :]
-        replace!(headers, alt_keys...)
-        Symbol.(headers), view(x, 2:xl_nrow(x), :)
-    else
-        gen_column_keys(xl_ncol(x), alt_keys), x
-    end
-
-    replace!(column_keys, alt_keys...)
-
-    return NamedTuple{Tuple(column_keys)}(eachcol(t_data))
-end
-
-#__ XLWorkbook
-
-"""
     XLWorkbook <: AbstractVector{XLSheet}
 
 Represents an Excel workbook containing [`XLSheet`](@ref).
@@ -292,7 +196,7 @@ Represents an Excel workbook containing [`XLSheet`](@ref).
 - `sheets::Vector{XLSheet}`: Workbook sheets.
 
 ## Accessors
-- `xl_names(x::XLWorkbook)`: Workbook sheet names.
+- `xl_sheetnames(x::XLWorkbook)`: Workbook sheet names.
 
 See also: [`xl_parse`](@ref).
 """
@@ -309,21 +213,22 @@ struct XLWorkbook <: AbstractVector{XLSheet}
                     result[row.r, column_addr] = xl[cell]
                 end
             end
-            XLSheet(ws.name, ws.sheetId, result)
+            XLSheet(ws.name, ws.sheetId, XLTable(result))
         end
         return new(r)
     end
 end
 
-xl_names(x::XLWorkbook) = map(xl_name, x.sheets)
-
 Base.size(x::XLWorkbook) = size(x.sheets)
+
 Base.getindex(x::XLWorkbook) = x.sheets
 Base.getindex(x::XLWorkbook, i::Int) = x.sheets[i]
 
+xl_sheetnames(x::XLWorkbook) = map(xl_sheetname, x.sheets)
+
 function Base.getindex(x::XLWorkbook, k::AbstractString)
     sheets = x[]
-    i = findfirst(sheet -> xl_name(sheet) == k, sheets)
+    i = findfirst(sheet -> xl_sheetname(sheet) == k, sheets)
     i === nothing && throw(KeyError(k))
     return sheets[i]
 end

--- a/src/print.jl
+++ b/src/print.jl
@@ -1,4 +1,4 @@
-# print
+# xl_print
 
 function compact_length(str::AbstractString; max_len::Int)
     return min(length(str), max_len)
@@ -23,7 +23,7 @@ function head_tail(x::AbstractVector, head::Int, tail::Int)
 end
 
 """
-    xl_print_sheet([io::IO], sheet::AbstractXLSheet; kw...)
+    xl_print([io::IO], sheet::AbstractXLSheet; kw...)
 
 Print a `sheet` as a table representation.
 
@@ -39,19 +39,19 @@ julia> xlsx = xl_parse(xl_sample_employee_xlsx())
 1-element XLWorkbook:
  1001x13 XLSheet("Employee")
 
-julia> xl_print_sheet(xlsx["Employee"]; header = true)
- Sheet │ eeid    full_name        job_title         ⋯  country        city       exit_date  
+julia> xl_print(xlsx["Employee"]; header = true)
+ Sheet │ eeid    full_name        job_title         ⋯  country        city       exit_date
 ───────┼───────────────────────────────────────────────────────────────────────────────────
-     2 │ E02387  Emily Davis      Sr. Manger        ⋯  United States  Seattle    44485.0    
-     3 │ E04105  Theodore Dinh    Technical Archi…  ⋯  China          Chongqing  nothing    
-     4 │ E02572  Luna Sanders     Director          ⋯  United States  Chicago    nothing    
-     5 │ E02832  Penelope Jordan  Computer System…  ⋯  United States  Chicago    nothing       
-     ⋮ │ ⋮       ⋮                ⋮                 ⋯  ⋮              ⋮          ⋮             
-  1000 │ E02521  Lily Nguyen      Sr. Analyst       ⋯  China          Chengdu    nothing    
-  1001 │ E03545  Sofia Cheng      Vice President    ⋯  United States  Miami      nothing 
+     2 │ E02387  Emily Davis      Sr. Manger        ⋯  United States  Seattle    44485.0
+     3 │ E04105  Theodore Dinh    Technical Archi…  ⋯  China          Chongqing  nothing
+     4 │ E02572  Luna Sanders     Director          ⋯  United States  Chicago    nothing
+     5 │ E02832  Penelope Jordan  Computer System…  ⋯  United States  Chicago    nothing
+     ⋮ │ ⋮       ⋮                ⋮                 ⋯  ⋮              ⋮          ⋮
+  1000 │ E02521  Lily Nguyen      Sr. Analyst       ⋯  China          Chengdu    nothing
+  1001 │ E03545  Sofia Cheng      Vice President    ⋯  United States  Miami      nothing
 ```
 """
-function xl_print_sheet(
+function xl_print(
     io::IO,
     sheet::AbstractXLSheet;
     title::AbstractString = "Sheet",
@@ -67,7 +67,7 @@ function xl_print_sheet(
     cols, row_start = if header
         view(sheet, 1, :), 2
     else
-        gen_column_keys(num_cols, Dict{String,String}()), 1
+        (index_to_column_letter.(1:num_cols), 1)
     end
     col_widths = map(enumerate(eachcol(sheet))) do (i, col)
         return max(
@@ -134,6 +134,10 @@ function xl_print_sheet(
     end
 end
 
-function xl_print_sheet(sheet::AbstractXLSheet; kw...)
-    return xl_print_sheet(stdout, sheet; kw...)
+function xl_print(sheet::AbstractXLSheet; kw...)
+    return xl_print(stdout, sheet; kw...)
+end
+
+function xl_print(x...; kw...)
+    return print(x...; kw...)
 end

--- a/src/table.jl
+++ b/src/table.jl
@@ -1,0 +1,136 @@
+# xl_table
+
+struct XLSheetRowIter
+    sheet::AbstractXLSheet
+    current_row::Int
+    total_rows::Int
+    columns::Vector{Symbol}
+end
+
+function XLSheetRowIter(x::AbstractXLSheet; header::Bool = false, alt_keys = nothing)
+    columns = header ? copy(x[1, :]) : index_to_column_letter.(1:xl_ncol(x))
+
+    if isa(alt_keys, AbstractVector)
+        length(alt_keys) == xl_ncol(x) || error("Column header mismatch: expected $(xl_ncol(x)) headers, but received $(length(alt_keys)).")
+        columns = alt_keys
+    elseif isa(alt_keys, AbstractDict)
+        columns = replace(columns, alt_keys...)
+    end
+
+    return XLSheetRowIter(x, header ? 2 : 1, xl_nrow(x), Symbol.(columns))
+end
+
+function Base.show(io::IO, x::XLSheetRowIter)
+    print(io, x.total_rows, "-rows XLSheetRowIter(\"", xl_sheetname(x.sheet), "\")")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", x::XLSheetRowIter)
+    show(io, x)
+    print(io, "\n")
+    show(io, x.sheet.table)
+end
+
+function Base.iterate(iter::XLSheetRowIter, state::Int = iter.current_row)
+    state > iter.total_rows && return nothing
+    rd = [iter.sheet[state, j] for j = 1:length(iter.columns)]
+    return (NamedTuple{Tuple(iter.columns)}(rd), state + 1)
+end
+
+function Base.length(iter::XLSheetRowIter)
+    return iter.total_rows - iter.current_row + 1
+end
+
+function Base.eltype(iter::XLSheetRowIter)
+    return NamedTuple{Tuple(iter.columns)}
+end
+
+"""
+    eachrow(x::AbstractXLSheet; kw...)
+
+Creates a table row iterator. Row slices are returned as `NamedTuple`.
+
+## Keyword arguments
+- `alt_keys`: Alternative custom column headers (`Dict{String,String}` or `Vector{String}`).
+- `header::Bool = false`: Use first row elements as column headers.
+
+## Examples
+```julia-repl
+julia> xlsx = xl_parse(xl_sample_stock_xlsx())
+
+julia for row in eachrow(xlsx["Stock"]; header = true)
+          println(row)
+      end
+(name = "MSFT", price = "430.16", h24 = "0.0007", volume = "11855456", ...)
+(name = "AAPL", price = "189.98", h24 = "-0.0005", volume = "36327000", ...)
+(name = "NVDA", price = "1064.69", h24 = "0.0045", volume = "42948000", ...)
+(name = "GOOG", price = "176.33", h24 = "-0.0006", volume = "11404000", ...)
+ ⋮
+(name = "JNJ", price = 146.97, h24 = 0.0007, volume = 7.173e6, ...)
+(name = "ORCL", price = 122.91, h24 = -0.0003, volume = 5.984e6, ...)
+```
+"""
+function Base.eachrow(x::AbstractXLSheet; kw...)
+    return XLSheetRowIter(x; kw...)
+end
+
+"""
+    xl_rowtable(sheet::AbstractXLSheet; kw...) -> Vector{NamedTuple}
+
+Converts sheet rows to a `Vector` of `NamedTuples`.
+
+## Keyword arguments
+- `alt_keys`: Alternative custom column headers (`Dict{String,String}` or `Vector{String}`).
+- `header::Bool = false`: Use first row elements as column headers.
+
+## Examples
+
+```julia-repl
+julia> xlsx = xl_parse(xl_sample_stock_xlsx())
+1-element XLWorkbook:
+ 41x6 XLSheet("Stock")
+
+julia> xl_rowtable(xlsx["Stock"]["A1:C30"], header = true)
+29-element Vector{NamedTuple{(:name, :price, :h24)}}:
+ (name = "MSFT", price = "430.16", h24 = "0.0007")
+ (name = "AAPL", price = "189.98", h24 = "-0.0005")
+ (name = "NVDA", price = "1064.69", h24 = "0.0045")
+ (name = "GOOG", price = "176.33", h24 = "-0.0006")
+ ⋮
+ (name = "LLY", price = 807.43, h24 = -0.0024)
+ (name = "AVGO", price = 1407.84, h24 = 0.0036)
+```
+"""
+function xl_rowtable(x::AbstractXLSheet; kw...)
+    return collect(XLSheetRowIter(x; kw...))
+end
+
+"""
+    xl_columntable(sheet::AbstractXLSheet; kw...) -> Vector{NamedTuple}
+
+Converts sheet columns to a `Vector` of `NamedTuples`.
+
+## Keyword arguments
+- `alt_keys`: Alternative custom column headers (`Dict{String,String}` or `Vector{String}`).
+- `header::Bool = false`: Use first row elements as column headers.
+
+## Examples
+
+```julia-repl
+julia> xlsx = xl_parse(xl_sample_stock_xlsx())
+1-element XLWorkbook:
+ 41x6 XLSheet("Stock")
+
+julia> alt_keys = Dict("A" => "Name", "B" => "Price", "C" => "H24");
+
+julia> xl_columntable(xlsx["Stock"][2:end, 1:3]; alt_keys)
+(
+    Name = Any["MSFT", "AAPL"  …  "JNJ", "ORCL"]
+    Price = Any[430.16, 189.98  …  146.97, 122.91],
+    H24 = Any[0.0007, -0.0005  …  0.0007, -0.0003],
+)
+```
+"""
+function xl_columntable(x::AbstractXLSheet; kw...)
+    iter = XLSheetRowIter(x; kw...)
+    return NamedTuple{Tuple(iter.columns)}(eachcol(x[iter.current_row:iter.total_rows, :]))
+end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -5,7 +5,7 @@ xlsx = xl_parse(read("xl_data/general_tables.xlsx"))
 @testset "Workbook interface" begin
     @testset "Case №1: Accessors" begin
         @test length(xlsx) == 13
-        @test xl_names(xlsx) == [
+        @test xl_sheetnames(xlsx) == [
             "general",
             "table3",
             "table4",
@@ -45,7 +45,7 @@ end
     @testset "Case №1: Accessors" begin
         @test xl_nrow(sheet) == 10
         @test xl_ncol(sheet) == 2
-        @test xl_name(sheet) == "general"
+        @test xl_sheetname(sheet) == "general"
     end
 
     @testset "Case №2: Indexing" begin
@@ -139,6 +139,31 @@ end
             (alt_text = "bigint neg", regular_text = "-100000000000000"),
         ]
 
+        @test xl_rowtable(sheet; alt_keys = ["alt_text", "regular_text"]) == [
+            (alt_text = "text", regular_text = "regular_text"),
+            (alt_text = "integer", regular_text = 102.0),
+            (alt_text = "float", regular_text = 102.2),
+            (alt_text = "date", regular_text = 30422.0),
+            (alt_text = "hour", regular_text = 1.8227199074074074),
+            (alt_text = "datetime", regular_text = 43206.805451388886),
+            (alt_text = "float cient", regular_text = -220.0),
+            (alt_text = "integer neg", regular_text = -2000.0),
+            (alt_text = "bigint", regular_text = 1.0e14),
+            (alt_text = "bigint neg", regular_text = "-100000000000000"),
+        ]
+
+        @test xl_rowtable(sheet; header = true, alt_keys = ["alt_text", "regular_text"]) == [
+            (alt_text = "integer", regular_text = 102.0),
+            (alt_text = "float", regular_text = 102.2),
+            (alt_text = "date", regular_text = 30422.0),
+            (alt_text = "hour", regular_text = 1.8227199074074074),
+            (alt_text = "datetime", regular_text = 43206.805451388886),
+            (alt_text = "float cient", regular_text = -220.0),
+            (alt_text = "integer neg", regular_text = -2000.0),
+            (alt_text = "bigint", regular_text = 1.0e14),
+            (alt_text = "bigint neg", regular_text = "-100000000000000"),
+        ]
+
         @test xl_columntable(sheet) == (
             A = Any[
                 "text",
@@ -192,6 +217,58 @@ end
         )
 
         @test xl_columntable(sheet; header = true, alt_keys = Dict("text" => "alt_text")) == (
+            alt_text = Any[
+                "integer",
+                "float",
+                "date",
+                "hour",
+                "datetime",
+                "float cient",
+                "integer neg",
+                "bigint",
+                "bigint neg",
+            ],
+            regular_text = Any[
+                102.0,
+                102.2,
+                30422.0,
+                1.8227199074074074,
+                43206.805451388886,
+                -220.0,
+                -2000.0,
+                1.0e14,
+                "-100000000000000",
+            ],
+        )
+
+        @test xl_columntable(sheet; alt_keys = ["alt_text", "regular_text"]) == (
+            alt_text = Any[
+                "text",
+                "integer",
+                "float",
+                "date",
+                "hour",
+                "datetime",
+                "float cient",
+                "integer neg",
+                "bigint",
+                "bigint neg",
+            ],
+            regular_text = Any[
+                "regular_text",
+                102.0,
+                102.2,
+                30422.0,
+                1.8227199074074074,
+                43206.805451388886,
+                -220.0,
+                -2000.0,
+                1.0e14,
+                "-100000000000000",
+            ],
+        )
+
+        @test xl_columntable(sheet; header = true, alt_keys = ["alt_text", "regular_text"]) == (
             alt_text = Any[
                 "integer",
                 "float",
@@ -317,6 +394,31 @@ end
             (alt_text = "bigint neg", regular_text = "-100000000000000"),
         ]
 
+        @test xl_rowtable(table; alt_keys = ["alt_text", "regular_text"]) == [
+            (alt_text = "text", regular_text = "regular_text"),
+            (alt_text = "integer", regular_text = 102.0),
+            (alt_text = "float", regular_text = 102.2),
+            (alt_text = "date", regular_text = 30422.0),
+            (alt_text = "hour", regular_text = 1.8227199074074074),
+            (alt_text = "datetime", regular_text = 43206.805451388886),
+            (alt_text = "float cient", regular_text = -220.0),
+            (alt_text = "integer neg", regular_text = -2000.0),
+            (alt_text = "bigint", regular_text = 1.0e14),
+            (alt_text = "bigint neg", regular_text = "-100000000000000"),
+        ]
+
+        @test xl_rowtable(table; header = true, alt_keys = ["alt_text", "regular_text"]) == [
+            (alt_text = "integer", regular_text = 102.0),
+            (alt_text = "float", regular_text = 102.2),
+            (alt_text = "date", regular_text = 30422.0),
+            (alt_text = "hour", regular_text = 1.8227199074074074),
+            (alt_text = "datetime", regular_text = 43206.805451388886),
+            (alt_text = "float cient", regular_text = -220.0),
+            (alt_text = "integer neg", regular_text = -2000.0),
+            (alt_text = "bigint", regular_text = 1.0e14),
+            (alt_text = "bigint neg", regular_text = "-100000000000000"),
+        ]
+
         @test xl_columntable(table) == (
             A = Any[
                 "text",
@@ -370,6 +472,58 @@ end
         )
 
         @test xl_columntable(table; header = true, alt_keys = Dict("text" => "alt_text")) == (
+            alt_text = Any[
+                "integer",
+                "float",
+                "date",
+                "hour",
+                "datetime",
+                "float cient",
+                "integer neg",
+                "bigint",
+                "bigint neg",
+            ],
+            regular_text = Any[
+                102.0,
+                102.2,
+                30422.0,
+                1.8227199074074074,
+                43206.805451388886,
+                -220.0,
+                -2000.0,
+                1.0e14,
+                "-100000000000000",
+            ],
+        )
+
+        @test xl_columntable(table; alt_keys = ["alt_text", "regular_text"]) == (
+            alt_text = Any[
+                "text",
+                "integer",
+                "float",
+                "date",
+                "hour",
+                "datetime",
+                "float cient",
+                "integer neg",
+                "bigint",
+                "bigint neg",
+            ],
+            regular_text = Any[
+                "regular_text",
+                102.0,
+                102.2,
+                30422.0,
+                1.8227199074074074,
+                43206.805451388886,
+                -220.0,
+                -2000.0,
+                1.0e14,
+                "-100000000000000",
+            ],
+        )
+
+        @test xl_columntable(table; header = true, alt_keys = ["alt_text", "regular_text"]) == (
             alt_text = Any[
                 "integer",
                 "float",


### PR DESCRIPTION
### Pull request checklist

- [x] Did you bump the project version?
- [x] Did you add a description to the Pull Request?
- [x] Did you add new tests?
- [x] Did you add reviewers?

## 2.0.0

### Added

- Added the ability to set headers using a vector for methods `xl_rowtable` and `xl_columntable`.
- Added support for rows iteration by `Base.eachrow` method.
- Added method `xl_open` for reading and parsing XL files.
- Added methods `column_letter_to_index` and `index_to_column_letter` to the documentation.
- General fixes and improvements.

### Changed

- Renamed accessor methods `xl_name` and `xl_names` to `xl_sheetname` and `xl_sheetnames`.
- Renamed print method `xl_print_sheet` to `xl_print`.