### PR TITLE
Fix applyNumberFormat field type in XFItem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OpenXL"
 uuid = "5439f3e2-bb62-4031-b438-a07447f64eb9"
-version = "3.2.0"
+version = "3.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/xl/styles.xml.jl
+++ b/src/xl/styles.xml.jl
@@ -11,7 +11,7 @@ struct XFItem
     fillId::Union{Nothing,Int64}
     borderId::Union{Nothing,Int64}
     xfId::Union{Nothing,Int64}
-    applyNumberFormat::Union{Nothing,Int64}
+    applyNumberFormat::Union{Nothing,Bool}
     quotePrefix::Union{Nothing,Int64}
 end
 


### PR DESCRIPTION
### Pull request checklist

- [x] Did you bump the project version?
- [x] Did you add a description to the Pull Request?
- [ ] Did you add new tests?
- [x] Did you add reviewers?

  ## Summary
  - Fix type of `applyNumberFormat` in `XFItem` (`Int64` → `Bool`) to match the OOXML schema (`xsd:boolean`).
  - Prevents deserialization errors on `.xlsx` files where `applyNumberFormat` is serialized as `true`/`false` rather than `1`/`0`.